### PR TITLE
Add fallback for raw_info from /v1/users/self

### DIFF
--- a/lib/omniauth/strategies/instagram.rb
+++ b/lib/omniauth/strategies/instagram.rb
@@ -29,6 +29,12 @@ module OmniAuth
 
       def raw_info
         @data ||= access_token.params["user"]
+        unless @data
+          access_token.options[:mode] = :query
+          access_token.options[:param_name] = "access_token"
+          @data ||= access_token.get('/v1/users/self').parsed['data'] || {}
+        end
+        @data
       end
     end
   end


### PR DESCRIPTION
Like for omniauth-facebook, this allows to ask about identity a second time to check them and fetch identity from an access_token
