### PR TITLE
Depend only on major versions of omniauth, omniauth-oauth2

### DIFF
--- a/omniauth-instagram.gemspec
+++ b/omniauth-instagram.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = OmniAuth::Instagram::VERSION
 
-  gem.add_dependency 'omniauth', '~> 1.0'
-  gem.add_dependency 'omniauth-oauth2', '~> 1.0'
+  gem.add_dependency 'omniauth', '~> 1'
+  gem.add_dependency 'omniauth-oauth2', '~> 1'
   gem.add_development_dependency 'rspec', '~> 2.12'
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'simplecov'


### PR DESCRIPTION
We can then install omniauth version 1.1.x, not be restricted to 1.0.x.
