### PR TITLE
Dynamic Instagram Callback Url

### DIFF
--- a/lib/omniauth/strategies/instagram.rb
+++ b/lib/omniauth/strategies/instagram.rb
@@ -9,6 +9,10 @@ module OmniAuth
         :token_url => 'https://api.instagram.com/oauth/access_token'
       }
 
+      configure do |c|
+        c.full_host = 'http://foo.kitcrm.com'
+      end
+
       def request_phase
         options[:scope] ||= 'basic'
         options[:response_type] ||= 'code'

--- a/lib/omniauth/strategies/instagram.rb
+++ b/lib/omniauth/strategies/instagram.rb
@@ -31,7 +31,7 @@ module OmniAuth
       end
       
       def callback_url
-        options[:callback_url] || super
+        options.callback_url || super
       end
 
       def raw_info

--- a/lib/omniauth/strategies/instagram.rb
+++ b/lib/omniauth/strategies/instagram.rb
@@ -12,8 +12,7 @@ module OmniAuth
       configure do |c|
         c.full_host = 'http://foo.kitcrm.com'
         OmniAuth.logger.send(:info, "setting full host")
-        OmniAuth.logger.send(:info, options.inspect)
-        OmniAuth.logger.send(:info, default_options.inspect)
+        
       end
 
       def request_phase

--- a/lib/omniauth/strategies/instagram.rb
+++ b/lib/omniauth/strategies/instagram.rb
@@ -11,7 +11,9 @@ module OmniAuth
 
       configure do |c|
         c.full_host = 'http://foo.kitcrm.com'
-        log :info, 'Setting full host.' 
+        OmniAuth.logger.send(:info, "setting full host")
+        OmniAuth.logger.send(:info, options.inspect)
+        OmniAuth.logger.send(:info, default_options.inspect)
       end
 
       def request_phase

--- a/lib/omniauth/strategies/instagram.rb
+++ b/lib/omniauth/strategies/instagram.rb
@@ -9,11 +9,7 @@ module OmniAuth
         :token_url => 'https://api.instagram.com/oauth/access_token'
       }
 
-      configure do |c|
-        c.full_host = 'http://foo.kitcrm.com'
-        OmniAuth.logger.send(:info, "setting full host")
-        
-      end
+      option :callback_url
 
       def request_phase
         options[:scope] ||= 'basic'
@@ -32,6 +28,10 @@ module OmniAuth
           'bio'      => raw_info['bio'],
           'website'  => raw_info['website'],
         }
+      end
+      
+      def callback_url
+        options[:callback_url] || super
       end
 
       def raw_info

--- a/lib/omniauth/strategies/instagram.rb
+++ b/lib/omniauth/strategies/instagram.rb
@@ -11,6 +11,7 @@ module OmniAuth
 
       configure do |c|
         c.full_host = 'http://foo.kitcrm.com'
+        log :info, 'Setting full host.' 
       end
 
       def request_phase

--- a/spec/omniauth/strategies/instagram_spec.rb
+++ b/spec/omniauth/strategies/instagram_spec.rb
@@ -18,4 +18,34 @@ describe OmniAuth::Strategies::Instagram do
       expect(subject.options.client_options.token_url).to eq('https://api.instagram.com/oauth/access_token')
     end
   end
+
+  describe "callback url" do
+
+    let(:omniauth_strategy) { OmniAuth::Strategies::Instagram.new({}, options) }
+
+    subject { omniauth_strategy.callback_url }
+
+    context "with callback url" do
+
+      let(:options) { {callback_url: "https://example.com/auth/callback"} }
+
+      it "uses passed callback_url" do
+        expect(subject).to eq(options[:callback_url])
+      end
+    end
+
+    context "without callback url" do
+
+      let(:options) { {} }
+
+      before do
+        omniauth_strategy.instance_variable_set("@env", {})
+        omniauth_strategy.should_receive(:full_host).and_return("http://www.example.com")
+      end
+
+      it "does not set callback url" do
+        expect(subject).to eq("http://www.example.com/auth/instagram/callback")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Instagram is very strict about authing against www.example.com / example.com. Since I can only set one valid oauth redirect url on instagram client settings, I am forcing my callback to www.example.com so it doesn't matter which subdomain the user oauth connects from.
