### PR TITLE
Update Instagram API url

### DIFF
--- a/lib/omniauth/strategies/instagram.rb
+++ b/lib/omniauth/strategies/instagram.rb
@@ -4,9 +4,9 @@ module OmniAuth
   module Strategies
     class Instagram < OmniAuth::Strategies::OAuth2
       option :client_options, {
-        :site => 'https://api.instagram.com',
-        :authorize_url => 'https://api.instagram.com/oauth/authorize',
-        :token_url => 'https://api.instagram.com/oauth/access_token'
+        :site => 'https://www.instagram.com',
+        :authorize_url => 'https://www.instagram.com/oauth/authorize',
+        :token_url => 'https://www.instagram.com/oauth/access_token'
       }
 
       def callback_url

--- a/spec/omniauth/strategies/instagram_spec.rb
+++ b/spec/omniauth/strategies/instagram_spec.rb
@@ -7,15 +7,15 @@ describe OmniAuth::Strategies::Instagram do
     end
 
     it "should have the correct site" do
-      expect(subject.options.client_options.site).to eq('https://api.instagram.com')
+      expect(subject.options.client_options.site).to eq('https://www.instagram.com')
     end
 
     it "should have the correct authorize url" do
-      expect(subject.options.client_options.authorize_url).to eq('https://api.instagram.com/oauth/authorize')
+      expect(subject.options.client_options.authorize_url).to eq('https://www.instagram.com/oauth/authorize')
     end
 
     it "should have the correct token url" do
-      expect(subject.options.client_options.token_url).to eq('https://api.instagram.com/oauth/access_token')
+      expect(subject.options.client_options.token_url).to eq('https://www.instagram.com/oauth/access_token')
     end
   end
 end


### PR DESCRIPTION
## Issue
Recently many users have been facing the `Invalid Credentials` error because Instagram API responded with
```
{
  "code": 400,
  "error_type": "OAuthException",
  "error_message":
  "Matching code was not found or was already used."
}
```

## Investigation
It seems that Instagram has `api.instagram.com` redirect to `www.instagram.com`.

```
curl -Ls -o /dev/null -w %{url_effective} https://api.instagram.com
https://www.instagram.com
```

## Proposed solution
Even though Instagram has not announced this change officially, but they have tested it since July (as people reported the same issue in stackoverflow)

To stop the frustration, we should change the api url.

 