### PR TITLE
handle "is_business" part of hash

### DIFF
--- a/lib/omniauth/strategies/instagram.rb
+++ b/lib/omniauth/strategies/instagram.rb
@@ -27,7 +27,8 @@ module OmniAuth
           'name'     => raw_info['full_name'],
           'image'    => raw_info['profile_picture'],
           'bio'      => raw_info['bio'],
-          'website'  => raw_info['website']
+          'website'  => raw_info['website'],
+          'is_business' => raw_info['is_business']
         }
       end
 


### PR DESCRIPTION
As part of Instagram's migration to the new Business API, the `user` hash now has an `is_business` flag denoting whether the profile is a business profile or not. This is useful to developers as it indicates that further information is available on the [Graph API](https://business.instagram.com/blog/new-instagram-api-features)