### PR TITLE
Add auth_scheme param to client options in strategy

### DIFF
--- a/lib/omniauth/strategies/instagram.rb
+++ b/lib/omniauth/strategies/instagram.rb
@@ -5,7 +5,8 @@ module OmniAuth
     class Instagram < OmniAuth::Strategies::OAuth2
       option :client_options,         site: 'https://api.instagram.com',
                                       authorize_url: 'https://api.instagram.com/oauth/authorize',
-                                      token_url: 'https://api.instagram.com/oauth/access_token'
+                                      token_url: 'https://api.instagram.com/oauth/access_token',
+                                      auth_scheme: :request_body
 
       def callback_url
         full_host + script_name + callback_path


### PR DESCRIPTION
Should address the problem of `Authentication failure! invalid_credentials: OAuth2::Error, invalid_request: Missing required parameter: client_id. {"error":"invalid_request","error_description":"Missing required parameter: client_id."}` when trying to fetch Instagram basic using Omniauth in combination with Devise.

Details are mentioned [here](https://github.com/omniauth/omniauth/issues/1101).